### PR TITLE
Fix typo

### DIFF
--- a/demo/instrument_demo/xcuitest.py
+++ b/demo/instrument_demo/xcuitest.py
@@ -6,7 +6,7 @@ import time
 from distutils.version import LooseVersion
 
 from ios_device.servers.DTXSever import DTXServerRPCRawObj, DTXEnum
-from ios_device.servers.Installation import InstallationProxy
+from ios_device.servers.Installation import InstallationProxyService
 from ios_device.servers.Instrument import InstrumentServer
 from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.testmanagerd import TestManagerdLockdown
@@ -31,7 +31,7 @@ class RunXCUITest(threading.Thread):
             logging.info(f" {res.parsed} : {get_auxiliary_text(res.raw)}")
 
         self.lockdown = LockdownClient(udid=self.udid,network=False)
-        installation = InstallationProxy(lockdown=self.lockdown)
+        installation = InstallationProxyService(lockdown=self.lockdown)
         app_info = installation.find_bundle_id(self.bundle_id)
         if not app_info:
             raise Exception("No app matches", self.bundle_id)

--- a/demo/instrument_demo/xcuitest.py
+++ b/demo/instrument_demo/xcuitest.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 from ios_device.servers.DTXSever import DTXServerRPCRawObj, DTXEnum
 from ios_device.servers.Installation import InstallationProxy
 from ios_device.servers.Instrument import InstrumentServer
-from ios_device.servers.house_arrest import HouseArrestClient
+from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.testmanagerd import TestManagerdLockdown
 from ios_device.util.bpylist2 import archive
 from ios_device.util._types import XCTestConfiguration, NSURL, NSUUID
@@ -96,7 +96,7 @@ class RunXCUITest(threading.Thread):
             "sessionIdentifier": session_identifier,
         }))
 
-        fsync = HouseArrestClient(self.lockdown)
+        fsync = HouseArrestService(self.lockdown)
         fsync.send_command(self.bundle_id)
         for fname in fsync.read_directory("/tmp"):
             if fname.endswith(".xctestconfiguration"):

--- a/ios_device/cli/base.py
+++ b/ios_device/cli/base.py
@@ -4,7 +4,7 @@ import uuid
 from distutils.version import LooseVersion
 
 from ios_device.servers.DTXSever import DTXServerRPCRawObj, DTXEnum
-from ios_device.servers.Installation import InstallationProxyServiceService
+from ios_device.servers.Installation import InstallationProxyService
 from ios_device.servers.Instrument import InstrumentServer
 from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.testmanagerd import TestManagerdLockdown
@@ -389,7 +389,7 @@ class InstrumentsBase:
         def _callback(res):
             log.info(f" {res.parsed} : {get_auxiliary_text(res.raw)}")
 
-        with InstallationProxyServiceService(lockdown=self.lock_down) as install:
+        with InstallationProxyService(lockdown=self.lock_down) as install:
             app_info = install.find_bundle_id(bundle_id)
             if not app_info:
                 log.warning(f"No app matches {bundle_id}")

--- a/ios_device/cli/base.py
+++ b/ios_device/cli/base.py
@@ -4,7 +4,7 @@ import uuid
 from distutils.version import LooseVersion
 
 from ios_device.servers.DTXSever import DTXServerRPCRawObj, DTXEnum
-from ios_device.servers.Installation import InstallationProxyService
+from ios_device.servers.Installation import InstallationProxyServiceService
 from ios_device.servers.Instrument import InstrumentServer
 from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.testmanagerd import TestManagerdLockdown
@@ -389,7 +389,7 @@ class InstrumentsBase:
         def _callback(res):
             log.info(f" {res.parsed} : {get_auxiliary_text(res.raw)}")
 
-        with InstallationProxyService(lockdown=self.lock_down) as install:
+        with InstallationProxyServiceService(lockdown=self.lock_down) as install:
             app_info = install.find_bundle_id(bundle_id)
             if not app_info:
                 log.warning(f"No app matches {bundle_id}")

--- a/ios_device/cli/mobile.py
+++ b/ios_device/cli/mobile.py
@@ -2,7 +2,7 @@ import click
 
 from ios_device.cli.base import InstrumentsBase
 from ios_device.cli.cli import Command, print_json
-from ios_device.servers.Installation import InstallationProxyService
+from ios_device.servers.Installation import InstallationProxyServiceService
 from ios_device.servers.crash_log import CrashLogService
 from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.mc_install import MCInstallService
@@ -133,28 +133,28 @@ def apps_list(udid, network, json_format, user, system):
         app_types.append('System')
     if not app_types:
         app_types = ['User', 'System']
-    print_json(InstallationProxyService(udid=udid, network=network, logger=log).get_apps(app_types))
+    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).get_apps(app_types))
 
 
 @apps.command('uninstall', cls=Command)
 @click.option('-b', '--bundle_id', default=None, help='Process app bundleId to filter')
 def uninstall(udid, network, json_format, bundle_id):
     """ uninstall app by given bundle_id """
-    print_json(InstallationProxyService(udid=udid, network=network, logger=log).uninstall(bundle_id))
+    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).uninstall(bundle_id))
 
 
 @apps.command('install', cls=Command)
 @click.option('--ipa_path', type=click.Path(exists=True))
 def install(udid, network, json_format, ipa_path):
     """ install given .ipa """
-    print_json(InstallationProxyService(udid=udid, network=network, logger=log).install(ipa_path))
+    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).install(ipa_path))
 
 
 @apps.command('upgrade', cls=Command)
 @click.option('--ipa_path', type=click.Path(exists=True))
 def upgrade(udid, network, json_format, ipa_path):
     """ install given .ipa """
-    print_json(InstallationProxyService(udid=udid, network=network, logger=log).upgrade(ipa_path))
+    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).upgrade(ipa_path))
 
 
 @apps.command('shell', cls=Command)

--- a/ios_device/cli/mobile.py
+++ b/ios_device/cli/mobile.py
@@ -2,7 +2,7 @@ import click
 
 from ios_device.cli.base import InstrumentsBase
 from ios_device.cli.cli import Command, print_json
-from ios_device.servers.Installation import InstallationProxyServiceService
+from ios_device.servers.Installation import InstallationProxyService
 from ios_device.servers.crash_log import CrashLogService
 from ios_device.servers.house_arrest import HouseArrestService
 from ios_device.servers.mc_install import MCInstallService
@@ -133,28 +133,28 @@ def apps_list(udid, network, json_format, user, system):
         app_types.append('System')
     if not app_types:
         app_types = ['User', 'System']
-    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).get_apps(app_types))
+    print_json(InstallationProxyService(udid=udid, network=network, logger=log).get_apps(app_types))
 
 
 @apps.command('uninstall', cls=Command)
 @click.option('-b', '--bundle_id', default=None, help='Process app bundleId to filter')
 def uninstall(udid, network, json_format, bundle_id):
     """ uninstall app by given bundle_id """
-    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).uninstall(bundle_id))
+    print_json(InstallationProxyService(udid=udid, network=network, logger=log).uninstall(bundle_id))
 
 
 @apps.command('install', cls=Command)
 @click.option('--ipa_path', type=click.Path(exists=True))
 def install(udid, network, json_format, ipa_path):
     """ install given .ipa """
-    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).install(ipa_path))
+    print_json(InstallationProxyService(udid=udid, network=network, logger=log).install(ipa_path))
 
 
 @apps.command('upgrade', cls=Command)
 @click.option('--ipa_path', type=click.Path(exists=True))
 def upgrade(udid, network, json_format, ipa_path):
     """ install given .ipa """
-    print_json(InstallationProxyServiceService(udid=udid, network=network, logger=log).upgrade(ipa_path))
+    print_json(InstallationProxyService(udid=udid, network=network, logger=log).upgrade(ipa_path))
 
 
 @apps.command('shell', cls=Command)

--- a/ios_device/cli/mobile.py
+++ b/ios_device/cli/mobile.py
@@ -60,7 +60,7 @@ def crash_shell(udid, network, json_format):
 @click.option('-b', '--bundle_id', default=None, help='Process app bundleId to filter')
 def cmd_house(udid, network, json_format, bundle_id):
     """ file management per application bundle """
-    crash_server = HouseArrestClient(udid=udid, network=network, logger=log)
+    crash_server = HouseArrestService(udid=udid, network=network, logger=log)
     crash_server.shell(bundle_id)
 
 

--- a/ios_device/py_ios_device.py
+++ b/ios_device/py_ios_device.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from numpy import long, mean
 
 from ios_device.servers.DTXSever import InstrumentRPCParseError
-from ios_device.servers.Installation import InstallationProxy
+from ios_device.servers.Installation import InstallationProxyService
 from ios_device.servers.Instrument import InstrumentServer
 from ios_device.util import api_util
 from ios_device.util.api_util import PyIOSDeviceException, RunXCUITest
@@ -409,7 +409,7 @@ def get_device(device_id: str = None, rpc_channel: InstrumentServer = None):
     :param rpc_channel:
     :return:
     """
-    current_device = InstallationProxy(udid=device_id, lockdown=rpc_channel.lockdown if rpc_channel else None)
+    current_device = InstallationProxyService(udid=device_id, lockdown=rpc_channel.lockdown if rpc_channel else None)
     return current_device
 
 

--- a/ios_device/servers/house_arrest.py
+++ b/ios_device/servers/house_arrest.py
@@ -35,4 +35,4 @@ class HouseArrestService(AFCClient):
 
 
 if __name__ == '__main__':
-    HouseArrestClient().shell('cn.rongcloud.rce.autotest.xctrunner')
+    HouseArrestService().shell('cn.rongcloud.rce.autotest.xctrunner')

--- a/ios_device/util/api_util.py
+++ b/ios_device/util/api_util.py
@@ -17,7 +17,7 @@ from ios_device.servers.testmanagerd import TestManagerdLockdown
 
 from ios_device.util._types import NSUUID, XCTestConfiguration, NSURL
 
-from ios_device.servers.Installation import InstallationProxy
+from ios_device.servers.Installation import InstallationProxyService
 from ios_device.util.forward import ForwardPorts
 
 from ios_device.util.lockdown import LockdownClient
@@ -173,7 +173,7 @@ class RunXCUITest(threading.Thread):
             self.callback(get_auxiliary_text(res.raw))
 
         lock_down = LockdownClient(udid=self.device_id)
-        installation = InstallationProxy(lockdown=lock_down)
+        installation = InstallationProxyService(lockdown=lock_down)
 
         if self.pair_ports:
             self.forward = True

--- a/ios_device/util/api_util.py
+++ b/ios_device/util/api_util.py
@@ -9,7 +9,7 @@ from _ctypes import Structure
 from ctypes import c_byte, c_uint16, c_uint32
 from distutils.version import LooseVersion
 
-from ios_device.servers.house_arrest import HouseArrestClient
+from ios_device.servers.house_arrest import HouseArrestService
 
 from ios_device.util.bpylist2 import archive
 
@@ -245,7 +245,7 @@ class RunXCUITest(threading.Thread):
             "sessionIdentifier": session_identifier,
         }))
 
-        fsync = HouseArrestClient(lock_down)
+        fsync = HouseArrestService(lock_down)
         fsync.send_command(self.bundle_id)
         for fname in fsync.read_directory("/tmp"):
             if fname.endswith(".xctestconfiguration"):


### PR DESCRIPTION
`HouseArrestClient` was renamed to `HouseArrestService`, but one of it usages was not replaced