### PR TITLE
fix: avoid raising exception when app is None in get_pid

### DIFF
--- a/ios_device/cli/base.py
+++ b/ios_device/cli/base.py
@@ -163,7 +163,9 @@ class InstrumentsBase:
         pid = None
         if bundle_id:
             app = self.application_listing(bundle_id)
-            name = app.get('ExecutableName')
+            if app:
+                name = app.get('ExecutableName')
+
         if name:
             processes = self.device_info.runningProcesses()
             for p in processes:


### PR DESCRIPTION
`AttributeError: 'NoneType' object has no attribute 'get'` could be raised when `bundle_id` is not on the device.

```
 % pyidevice apps kill --bundle_id 'a'
2022-02-05 16:59:07 [INFO] [LockDown] lockdown.py[line:71] Connecting Device 242bfcc998fd156df0bd0ad1dde8ab8e0a032114
2022-02-05 16:59:07 [INFO] [Instrument] Instrument.py[line:22] InstrumentServer init ...
2022-02-05 16:59:07 [INFO] [LockDown] lockdown.py[line:377] save path :/Users/kazuaki/.cache/pymobiledevice/242bfcc998fd156df0bd0ad1dde8ab8e0a032114.pem
2022-02-05 16:59:08 [WARNING] [Instrument] dvt.py[line:245] socket connection close
Traceback (most recent call last):
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/bin/pyidevice", line 8, in <module>
    sys.exit(cli())
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/ios_device/main.py", line 15, in cli
    cli_commands()
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/ios_device/cli/mobile.py", line 211, in cmd_kill
    pid = rpc.get_pid(bundle_id, name)
  File "/Users/kazuaki/.asdf/installs/python/3.10.2/lib/python3.10/site-packages/ios_device/cli/base.py", line 166, in get_pid
    name = app.get('ExecutableName')
AttributeError: 'NoneType' object has no attribute 'get'
```

It seems like this error should not be there to print warning messages as below:
```
% pyidevice apps kill --bundle_id 'a'
2022-02-05 16:32:06 [INFO] [LockDown] lockdown.py[line:71] Connecting Device 242bfcc998fd156df0bd0ad1dde8ab8e0a032114
2022-02-05 16:32:06 [INFO] [Instrument] Instrument.py[line:22] InstrumentServer init ...
2022-02-05 16:32:06 [INFO] [LockDown] lockdown.py[line:377] save path :/Users/kazuaki/.cache/pymobiledevice/242bfcc998fd156df0bd0ad1dde8ab8e0a032114.pem
2022-02-05 16:32:07 [WARNING] [Mobile] mobile.py[line:213] The ('a', None, None) did not start
Kill None ...
2022-02-05 16:32:07 [WARNING] [Instrument] dvt.py[line:245] socket connection close
```