### PR TITLE
fix: cannot import name 'long' from numpy

### DIFF
--- a/ios_device/py_ios_device.py
+++ b/ios_device/py_ios_device.py
@@ -4,7 +4,7 @@
 """
 import uuid
 from datetime import datetime
-from numpy import long, mean
+from numpy import int_ as long, mean
 
 from ios_device.util.exceptions import InstrumentRPCParseError
 from ios_device.servers.Installation import InstallationProxyService


### PR DESCRIPTION
env: python 3.9.6 ; numpy 1.24.2

![1](https://user-images.githubusercontent.com/10367702/222034098-7c881153-60bf-4a87-880f-0498f8ccc025.png)
