### PR TITLE
Fix Numpy error

### DIFF
--- a/ios_device/py_ios_device.py
+++ b/ios_device/py_ios_device.py
@@ -4,7 +4,7 @@
 """
 import uuid
 from datetime import datetime
-from numpy import long, mean
+from numpy import *
 
 from ios_device.util.exceptions import InstrumentRPCParseError
 from ios_device.servers.Installation import InstallationProxyService


### PR DESCRIPTION
Fixes this error:
```
/Users/myuser/myproject/venv/lib/python3.10/site-packages/ios_device/py_ios_device.py:7: FutureWarning: In the future `np.long` will be defined as the corresponding NumPy scalar.
  from numpy import long, mean
Traceback (most recent call last):
  File "/Users/myuser/myproject/test.py", line 1, in <module>
    from ios_device import py_ios_device
  File "/Users/myuser/myproject/venv/lib/python3.10/site-packages/ios_device/py_ios_device.py", line 7, in <module>
    from numpy import long, mean
ImportError: cannot import name 'long' from 'numpy' (/Users/myuser/myproject/venv/lib/python3.10/site-packages/numpy/__init__.py)
```