### PR TITLE
兼容有些 App 先收到 Initial Frame Rendering 的 END，然后再收到 BEIGIN 的问题

### DIFF
--- a/ios_device/util/lifecycle.py
+++ b/ios_device/util/lifecycle.py
@@ -45,7 +45,15 @@ class AppLifeCycle:
     def format_str(self):
         _tmp_sub_state = {}
         for key, events in self.events.items():
-            if events and events[-1].sub_state == 'Initial Frame Rendering':
+            finish = False
+            # 兼容有些 App 先收到 Initial Frame Rendering 的 END，然后再收到 BEIGIN 的问题
+            for event in events:
+                if event.sub_state == 'Initial Frame Rendering' and event.kind == 'BEGIN':
+                    finish = True
+            if len(events) == 0:
+                continue
+            last_event = events[-1]
+            if events and last_event.sub_state == 'Initial Frame Rendering' and last_event.kind == 'END' and finish:
                 for index, val in enumerate(events):
                     if val.kind == 'BEGIN':
                         _tmp_sub_state[val.sub_state] = self.format_timestamp(val.time)


### PR DESCRIPTION
正常的启动监控，是应该监控到如下几个时机：
```
 235.94 ms   Initializing-System Interface Initialization (Dyld init)
  36.03 ms   Initializing-Static Runtime Initialization
  12.27 ms   Launching-sceneWillConnectTo()
  12.65 ms   Launching-UIKit Initialization
 784.17 us   Launching-UIKit Scene Creation
  27.25 us   Launching-willFinishLaunchingWithOptions()
  19.17 us   Launching-UIKit Scene Creation
 472.22 ms   Launching-Initial Frame Rendering
App Thread Process ID:2956 Name:bili-universal, Process Total Time:757.86 ms
```
但是在测试过程中，发现有一些 App 会提前执行到 Initial Frame Rendering（END），导致监控的时机如下：
```
 680.17 ms Launching-didFinishLaunchingWithOptions()
  14.11 ms   Launching-UIKit Scene Creation
 758.12 ms   Launching-Initial Frame Rendering
App Thread Process ID:2543 Name:JD4iPhone, Process Total Time:1452.40 ms
```

导致启动数据不全，并且整体耗时有误差。

最新的代码已经修复解决，辛苦也 review 一下。